### PR TITLE
Always use the same enum types for identical value domains in DuckDB

### DIFF
--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -203,7 +203,7 @@ class ModelMetaclass(PydanticModelMetaclass):
         Returns:
             Set of column name strings.
         """
-        return set(cls.schema()["required"])
+        return set(cls.schema().get("required", {}))
 
     @property
     def nullable_columns(  # type: ignore
@@ -243,8 +243,10 @@ class ModelMetaclass(PydanticModelMetaclass):
         schema = cls.schema()
         props = schema["properties"]
         return {
-            column: PYDANTIC_TO_DUCKDB_TYPES[props[column]["type"]]
-            for column in cls.columns
+            column: f"{schema['title'].lower()}__{column.lower()}"
+            if "enum" in props
+            else PYDANTIC_TO_DUCKDB_TYPES[props["type"]]
+            for column, props in props.items()
         }
 
 

--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -240,14 +240,17 @@ class ModelMetaclass(PydanticModelMetaclass):
         Returns:
             Dictionary with column name keys and SQL type identifier strings.
         """
+        from patito.duckdb import _enum_type_name
+
         schema = cls.schema()
         props = schema["properties"]
-        return {
-            column: f"{schema['title'].lower()}__{column.lower()}"
-            if "enum" in props
-            else PYDANTIC_TO_DUCKDB_TYPES[props["type"]]
-            for column, props in props.items()
-        }
+        types = {}
+        for column, props in schema["properties"].items():
+            if "enum" in props:
+                types[column] = _enum_type_name(field_properties=props)
+            else:
+                types[column] = PYDANTIC_TO_DUCKDB_TYPES[props["type"]]
+        return types
 
 
 class Model(BaseModel, metaclass=ModelMetaclass):

--- a/tests/test_duckdb/test_relation.py
+++ b/tests/test_duckdb/test_relation.py
@@ -589,7 +589,7 @@ def test_with_missing_nullable_enum_columns():
         table_name="enum_table"
     )
     table_relation = db.table("enum_table")
-    assert table_relation.sql_types["enum_column"] == "enummodel__enum_column"
+    assert table_relation.sql_types["enum_column"].startswith("enum__")
 
     # We generate another dynamic relation where we expect the correct enum type
     null_relation = (
@@ -597,11 +597,17 @@ def test_with_missing_nullable_enum_columns():
         .set_model(EnumModel)
         .with_missing_nullable_columns()
     )
-    assert null_relation.sql_types["enum_column"] == "enummodel__enum_column"
+    assert (
+        null_relation.sql_types["enum_column"]
+        == table_relation.sql_types["enum_column"]
+    )
 
     # These two relations should now be unionable
     union_relation = null_relation + table_relation
-    assert union_relation.sql_types["enum_column"] == "enummodel__enum_column"
+    assert (
+        union_relation.sql_types["enum_column"]
+        == table_relation.sql_types["enum_column"]
+    )
     assert (
         union_relation.order("other_column asc")
         .to_df()
@@ -631,14 +637,18 @@ def test_with_missing_nullable_enum_columns_without_table():
         .set_model(EnumModel)
         .with_missing_nullable_columns()
     )
-    assert relation.sql_types["enum_column_1"] == "enummodel__enum_column_1"
-    assert relation.sql_types["enum_column_2"] == "enummodel__enum_column_2"
+    assert relation.sql_types["enum_column_1"].startswith("enum__")
+    assert relation.sql_types["enum_column_2"] == relation.sql_types["enum_column_1"]
 
     # And now we should be able to insert it into a new table
     relation.create_table(name="enum_table")
     table_relation = db.table("enum_table")
-    assert table_relation.sql_types["enum_column_1"] == "enummodel__enum_column_1"
-    assert table_relation.sql_types["enum_column_2"] == "enummodel__enum_column_2"
+    assert (
+        table_relation.sql_types["enum_column_1"] == relation.sql_types["enum_column_1"]
+    )
+    assert (
+        table_relation.sql_types["enum_column_2"] == relation.sql_types["enum_column_1"]
+    )
 
 
 def test_with_missing_defualtable_enum_columns():
@@ -654,7 +664,7 @@ def test_with_missing_defualtable_enum_columns():
         .set_model(EnumModel)
         .with_missing_defaultable_columns()
     )
-    assert relation.sql_types["enum_column"] == "enummodel__enum_column"
+    assert relation.sql_types["enum_column"].startswith("enum__")
 
 
 def test_relation_insert_into():


### PR DESCRIPTION
Also, always use the same enum type as long as the same values are present in the enum.