### PR TITLE
Use `null` as example data for nullable enum fields

### DIFF
--- a/src/patito/pydantic.py
+++ b/src/patito/pydantic.py
@@ -396,14 +396,14 @@ class Model(BaseModel, metaclass=ModelMetaclass):
             return properties["const"]
 
         elif "default" in properties:
-            # A default value has been specified in the model field definiton
+            # A default value has been specified in the model field definition
             return properties["default"]
-
-        elif "enum" in properties:
-            return properties["enum"][0]
 
         elif field not in non_nullable:
             return None
+
+        elif "enum" in properties:
+            return properties["enum"][0]
 
         elif field_type in {"integer", "number"}:
             # For integer and float types we must check if there are imposed bounds

--- a/tests/test_dummy_data.py
+++ b/tests/test_dummy_data.py
@@ -4,6 +4,7 @@ from typing import Optional
 
 import polars as pl
 import pytest
+from typing_extensions import Literal
 
 import patito as pt
 
@@ -94,3 +95,39 @@ def test_generation_of_unique_data():
     example_df = UniqueModel.examples({"bool_column": [True, False]})
     for column in UniqueModel.columns:
         assert example_df[column].is_duplicated().sum() == 0
+
+
+def test_enum_field_example_values():
+    """It should produce correct example values for enums."""
+
+    class DefaultEnumModel(pt.Model):
+        row_number: int
+        # Here the first value will be used as the example value
+        enum_field: Literal["a", "b", "c"]
+        # Here the default value will be used as the example value
+        default_enum_field: Literal["a", "b", "c"] = "b"
+        default_optional_enum_field: Optional[Literal["a", "b", "c"]] = "c"
+        # Here null will be used as the example value
+        none_default_optional_enum_field: Optional[Literal["a", "b", "c"]] = None
+
+    example_df = DefaultEnumModel.examples({"row_number": [1]})
+    correct_example_df = pl.DataFrame(
+        [
+            pl.Series("row_number", [1], dtype=pl.Int64),
+            pl.Series("enum_field", ["a"], dtype=pl.Categorical),
+            pl.Series("default_enum_field", ["b"], dtype=pl.Categorical),
+            pl.Series("default_optional_enum_field", ["c"], dtype=pl.Categorical),
+            pl.Series("none_default_optional_enum_field", [None], dtype=pl.Categorical),
+        ]
+    )
+
+    # Workaround for pola-rs/polars#4253
+    assert example_df.with_column(
+        pl.col("none_default_optional_enum_field").cast(pl.Categorical)
+    ).frame_equal(correct_example_df)
+
+    example_model = DefaultEnumModel.example()
+    assert example_model.enum_field == "a"
+    assert example_model.default_enum_field == "b"
+    assert example_model.default_optional_enum_field == "c"
+    assert example_model.none_default_optional_enum_field is None


### PR DESCRIPTION
This allows the user to both set literal values and `None` as the default value of optional enum fields. Includes work-around for pola-rs/polars#4253.