### PR TITLE
Add support for List annotated model fields

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -73,7 +73,7 @@ def coverage(session):
     session.run("codecov", *session.posargs)
 
 
-@nox.session(python=["3.9"])
+@nox.session(python=["3.11"])
 def type_check(session):
     """Run type-checking on project using pyright."""
     args = session.posargs or locations

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,7 +3,7 @@
 import enum
 import re
 from datetime import date, datetime, timedelta
-from typing import Optional, Type
+from typing import List, Optional, Type
 
 import polars as pl
 import pytest
@@ -217,6 +217,56 @@ def test_mapping_to_polars_dtypes():
         "duration_column": [pl.Duration],
         "categorical_column": [pl.Categorical, pl.Utf8],
         "null_column": [pl.Null],
+    }
+
+
+def test_mapping_to_polars_dtypes_with_lists():
+    """Model list fields should be mappable to polars dtypes."""
+
+    class CompleteModel(pt.Model):
+        str_column: List[str]
+        int_column: List[int]
+        float_column: List[float]
+        bool_column: List[bool]
+
+        date_column: List[date]
+        datetime_column: List[datetime]
+        duration_column: List[timedelta]
+
+        categorical_column: List[Literal["a", "b", "c"]]
+        null_column: List[None]
+
+    assert CompleteModel.dtypes == {
+        "str_column": pl.List(pl.Utf8),
+        "int_column": pl.List(pl.Int64),
+        "float_column": pl.List(pl.Float64),
+        "bool_column": pl.List(pl.Boolean),
+        "date_column": pl.List(pl.Date),
+        "datetime_column": pl.List(pl.Datetime),
+        "duration_column": pl.List(pl.Duration),
+        "categorical_column": pl.List(pl.Categorical),
+        "null_column": pl.List(pl.Null),
+    }
+
+    assert CompleteModel.valid_dtypes == {
+        "str_column": [pl.List(pl.Utf8)],
+        "int_column": [
+            pl.List(pl.Int64),
+            pl.List(pl.Int32),
+            pl.List(pl.Int16),
+            pl.List(pl.Int8),
+            pl.List(pl.UInt64),
+            pl.List(pl.UInt32),
+            pl.List(pl.UInt16),
+            pl.List(pl.UInt8),
+        ],
+        "float_column": [pl.List(pl.Float64), pl.List(pl.Float32)],
+        "bool_column": [pl.List(pl.Boolean)],
+        "date_column": [pl.List(pl.Date)],
+        "datetime_column": [pl.List(pl.Datetime)],
+        "duration_column": [pl.List(pl.Duration)],
+        "categorical_column": [pl.List(pl.Categorical), pl.List(pl.Utf8)],
+        "null_column": [pl.List(pl.Null)],
     }
 
 

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -2,7 +2,7 @@
 import enum
 import sys
 from datetime import date, datetime
-from typing import Optional
+from typing import List, Optional, Union
 
 import polars as pl
 import pytest
@@ -10,7 +10,39 @@ from typing_extensions import Literal
 
 import patito as pt
 from patito.exceptions import ValidationError
-from patito.validators import validate
+from patito.validators import _dewrap_optional, _is_optional, validate
+
+
+def test_is_optional():
+    """It should return True for optional types."""
+    assert _is_optional(Optional[int])
+    assert _is_optional(Union[int, None])
+    assert not _is_optional(int)
+
+
+@pytest.mark.skipif(
+    sys.version_info <= (3, 10),
+    reason="Using | as a type union operator is only supported from python 3.10.",
+)
+def test_is_optional_with_pipe_operator():
+    """It should return True for optional types."""
+    assert _is_optional(int | None)  # typing: ignore  # pragma: noqa
+
+
+def test_dewrap_optional():
+    """It should return the inner type of Optional types."""
+    assert _dewrap_optional(Optional[int]) is int
+    assert _dewrap_optional(Union[int, None]) is int
+    assert _dewrap_optional(int) is int
+
+
+@pytest.mark.skipif(
+    sys.version_info <= (3, 10),
+    reason="Using | as a type union operator is only supported from python 3.10.",
+)
+def test_dewrap_optional_with_pipe_operator():
+    """It should return the inner type of Optional types."""
+    assert _dewrap_optional(int | None) is int  # typing: ignore  # pragma: noqa
 
 
 def test_missing_column_validation():
@@ -175,6 +207,16 @@ def test_validate_dtype_checks():
         match="No valid dtype mapping found for column 'my_field'.",
     ):
         NonCompatibleModel.valid_dtypes
+
+    # The same goes for list-annotated fields
+    class NonCompatibleListModel(pt.Model):
+        my_field: List[object]
+
+    with pytest.raises(
+        NotImplementedError,
+        match="No valid dtype mapping found for column 'my_field'.",
+    ):
+        NonCompatibleListModel.valid_dtypes
 
     # It should also work with pandas data frames
     class PandasCompatibleModel(CompleteModel):
@@ -510,3 +552,45 @@ def test_optional_pipe_operator():
         }
     )
     OptionalEnumModel.validate(df)
+
+
+@pytest.mark.xfail(
+    condition=sys.version_info < (3, 8),
+    reason="Polars bug: list series can not be constructed with None values.",
+    raises=TypeError,
+    strict=True,
+)
+def test_validation_of_list_dtypes():
+    """It should be able to validate dtypes organized in lists."""
+
+    class ListModel(pt.Model):
+        int_list: List[int]
+        int_or_null_list: List[Optional[int]]
+        nullable_int_list: Optional[List[int]]
+        nullable_int_or_null_list: Optional[List[Optional[int]]]
+
+    valid_df = pl.DataFrame(
+        {
+            "int_list": [[1, 2], [3, 4]],
+            "int_or_null_list": [[1, 2], [3, None]],
+            "nullable_int_list": [[1, 2], None],
+            "nullable_int_or_null_list": [[1, None], None],
+        }
+    )
+    ListModel.validate(valid_df)
+
+    for old, new in [
+        # List items are not nullable
+        ("int_or_null_list", "int_list"),
+        ("int_or_null_list", "nullable_int_list"),
+        # List is not nullable
+        ("nullable_int_list", "int_list"),
+        ("nullable_int_list", "int_or_null_list"),
+        # Combination of both
+        ("nullable_int_or_null_list", "int_list"),
+        ("nullable_int_or_null_list", "int_or_null_list"),
+        ("nullable_int_or_null_list", "nullable_int_list"),
+    ]:
+        # print(old, new)
+        with pytest.raises(ValidationError):
+            ListModel.validate(valid_df.with_column(pl.col(old).alias(new)))

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -26,7 +26,7 @@ def test_is_optional():
 )
 def test_is_optional_with_pipe_operator():
     """It should return True for optional types."""
-    assert _is_optional(int | None)  # typing: ignore  # pragma: noqa
+    assert _is_optional(int | None)  # typing: ignore  # pragma: noqa  # pyright: ignore
 
 
 def test_dewrap_optional():
@@ -42,7 +42,9 @@ def test_dewrap_optional():
 )
 def test_dewrap_optional_with_pipe_operator():
     """It should return the inner type of Optional types."""
-    assert _dewrap_optional(int | None) is int  # typing: ignore  # pragma: noqa
+    assert (  # typing: ignore  # pragma: noqa  # pyright: ignore
+        _dewrap_optional(int | None) is int
+    )
 
 
 def test_missing_column_validation():


### PR DESCRIPTION
For instance, a field annotated as `typing.List[str]` will be mapped to `pl.List(pl.Utf8)`.