### PR TITLE
Support Polars 0.18 and fix failing duckdb tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ keywords = ["validation", "dataframe"]
 [tool.poetry.dependencies]
 python = "^3.7"
 pydantic = ">=1.7.0"
-polars = ">=0.15.2"
+polars = ">=0.18.3"
 # Required for typing.Literal in python3.7
 typing-extensions = "*"
 pandas = {version = "*", optional = true, python = "^3.8"}

--- a/src/patito/duckdb.py
+++ b/src/patito/duckdb.py
@@ -1795,7 +1795,7 @@ class Relation(Generic[ModelType]):
             # because polars is much more eager to store integer Series as 64-bit
             # integers. Otherwise there must be done a lot of manual casting whenever
             # you cross the boundary between DuckDB and polars.
-            return DataFrame._from_arrow(arrow_table).with_column(
+            return DataFrame._from_arrow(arrow_table).with_columns(
                 pl.col(pl.Int32).cast(pl.Int64)
             )
         except pa.ArrowInvalid:  # pragma: no cover
@@ -1809,7 +1809,7 @@ class Relation(Generic[ModelType]):
             ]
             non_enum_relation = self._relation.project(", ".join(casted_columns))
             arrow_table = non_enum_relation.to_arrow_table()
-            return DataFrame._from_arrow(arrow_table).with_column(
+            return DataFrame._from_arrow(arrow_table).with_columns(
                 pl.col(pl.Int32).cast(pl.Int64)
             )
 

--- a/src/patito/duckdb.py
+++ b/src/patito/duckdb.py
@@ -23,6 +23,8 @@ from typing import (
 
 import numpy as np
 import polars as pl
+# ArrowErrorException is not currently exported into the polars.exceptions type stub
+from polars.polars import ArrowErrorException
 import pyarrow as pa  # type: ignore[import]
 from pydantic import create_model
 from typing_extensions import Literal
@@ -1798,7 +1800,7 @@ class Relation(Generic[ModelType]):
             return DataFrame._from_arrow(arrow_table).with_columns(
                 pl.col(pl.Int32).cast(pl.Int64)
             )
-        except pa.ArrowInvalid:  # pragma: no cover
+        except (pa.ArrowInvalid, ArrowErrorException):  # pragma: no cover
             # Empty relations with enum columns can sometimes produce errors.
             # As a last-ditch effort, we convert such columns to VARCHAR.
             casted_columns = [

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -428,11 +428,11 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
                 derived_from = props["derived_from"]
                 dtype = self.model.dtypes[column_name]
                 if isinstance(derived_from, str):
-                    df = df.with_column(
+                    df = df.with_columns(
                         pl.col(derived_from).cast(dtype).alias(column_name)
                     )
                 elif isinstance(derived_from, pl.Expr):
-                    df = df.with_column(derived_from.cast(dtype).alias(column_name))
+                    df = df.with_columns(derived_from.cast(dtype).alias(column_name))
                 else:
                     raise TypeError(
                         "Can not derive dataframe column from type "
@@ -695,8 +695,8 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
     ) -> DF:
         return cast(DF, super().select(exprs=exprs))  # type: ignore[redundant-cast]
 
-    def with_column(self: DF, column: Union[pl.Series, pl.Expr]) -> DF:  # noqa: D102
-        return cast(DF, super().with_column(column=column))
+    def with_columns(self: DF, column: Union[pl.Series, pl.Expr]) -> DF:  # noqa: D102
+        return cast(DF, super().with_columns(column=column))
 
     def with_columns(  # noqa: D102
         self: DF,

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -14,6 +14,7 @@ from typing import (
 )
 
 import polars as pl
+from polars.type_aliases import IntoExpr
 from pydantic import create_model
 from typing_extensions import Literal
 
@@ -695,17 +696,9 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
     ) -> DF:
         return cast(DF, super().select(exprs))  # type: ignore[redundant-cast]
 
-    def with_columns(self: DF, column: Union[pl.Series, pl.Expr]) -> DF:  # noqa: D102
-        return cast(DF, super().with_columns(column=column))
-
     def with_columns(  # noqa: D102
         self: DF,
-        exprs: Union[
-            pl.Expr,
-            pl.Series,
-            Sequence[Union[pl.Expr, pl.Series]],
-            None,
-        ] = None,
+        exprs: IntoExpr = None,
         **named_exprs: Union[pl.Expr, pl.Series],
     ) -> DF:
         return cast(DF, super().with_columns(exprs, **named_exprs))

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -22,7 +22,7 @@ from patito.exceptions import MultipleRowsReturned, RowDoesNotExist
 
 if TYPE_CHECKING:
     import numpy as np
-    from polars.internals import WhenThen, WhenThenThen
+    from polars.functions.whenthen import WhenThen, WhenThenThen
 
     from patito.pydantic import Model
 

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -693,7 +693,7 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
             Sequence[Union[str, pl.Expr, pl.Series, "WhenThen", "WhenThenThen"]],
         ],
     ) -> DF:
-        return cast(DF, super().select(exprs=exprs))  # type: ignore[redundant-cast]
+        return cast(DF, super().select(exprs))  # type: ignore[redundant-cast]
 
     def with_columns(self: DF, column: Union[pl.Series, pl.Expr]) -> DF:  # noqa: D102
         return cast(DF, super().with_columns(column=column))
@@ -708,4 +708,4 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
         ] = None,
         **named_exprs: Union[pl.Expr, pl.Series],
     ) -> DF:
-        return cast(DF, super().with_columns(exprs=exprs, **named_exprs))
+        return cast(DF, super().with_columns(exprs, **named_exprs))

--- a/src/patito/polars.py
+++ b/src/patito/polars.py
@@ -5,6 +5,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
+    Iterable,
     Optional,
     Sequence,
     Type,
@@ -22,8 +23,6 @@ from patito.exceptions import MultipleRowsReturned, RowDoesNotExist
 
 if TYPE_CHECKING:
     import numpy as np
-    from polars.functions.whenthen import WhenThen, WhenThenThen
-
     from patito.pydantic import Model
 
 
@@ -688,17 +687,14 @@ class DataFrame(pl.DataFrame, Generic[ModelType]):
 
     def select(  # noqa: D102
         self: DF,
-        exprs: Union[
-            pl.Expr,
-            pl.Series,
-            Sequence[Union[str, pl.Expr, pl.Series, "WhenThen", "WhenThenThen"]],
-        ],
+        *exprs: IntoExpr,
+        **named_exprs: Iterable[IntoExpr],
     ) -> DF:
-        return cast(DF, super().select(exprs))  # type: ignore[redundant-cast]
+        return cast(DF, super().select(*exprs, **named_exprs))  # type: ignore[redundant-cast]
 
     def with_columns(  # noqa: D102
         self: DF,
-        exprs: IntoExpr = None,
-        **named_exprs: Union[pl.Expr, pl.Series],
+        *exprs: IntoExpr,
+        **named_exprs: Iterable[IntoExpr],
     ) -> DF:
-        return cast(DF, super().with_columns(exprs, **named_exprs))
+        return cast(DF, super().with_columns(*exprs, **named_exprs))

--- a/src/patito/validators.py
+++ b/src/patito/validators.py
@@ -275,7 +275,7 @@ def _find_errors(  # noqa: C901
             )
             if "_" in constraints.meta.root_names():
                 # An underscore is an alias for the current field
-                illegal_rows = dataframe.with_column(
+                illegal_rows = dataframe.with_columns(
                     pl.col(column_name).alias("_")
                 ).filter(constraints)
             else:

--- a/tests/test_duckdb/test_database.py
+++ b/tests/test_duckdb/test_database.py
@@ -34,7 +34,7 @@ def test_database(tmp_path):
 
     # Check that new database objects are isolated from previous ones
     another_db = pt.Database()
-    with pytest.raises(Exception, match="Table does not exist!"):
+    with pytest.raises(Exception, match="does not exist!"):
         db_table = another_db.table("table_name_1")
 
     # Check the parquet reading functionality
@@ -93,8 +93,7 @@ def test_database_create_table():
     with pytest.raises(
         Exception,
         match=(
-            "Failed to insert into table 'test_table': "
-            "NOT NULL constraint failed: test_table.int_column"
+            "NOT NULL constraint failed"
         ),
     ):
         null_relation.insert_into(table="test_table")
@@ -153,8 +152,7 @@ def test_validate_non_nullable_enum_columns():
     with pytest.raises(
         Exception,
         match=(
-            "Failed to insert into table 'enum_table': "
-            "NOT NULL constraint failed: enum_table.non_nullable_enum_column"
+            "NOT NULL constraint failed"
         ),
     ):
         invalid_relation.insert_into(table="enum_table")
@@ -166,7 +164,6 @@ def test_validate_non_nullable_enum_columns():
     with pytest.raises(
         Exception,
         match=(
-            ".*Failed to insert into table 'enum_table': "
             "Could not convert string 'd' to UINT8"
         ),
     ):
@@ -179,7 +176,6 @@ def test_validate_non_nullable_enum_columns():
     with pytest.raises(
         Exception,
         match=(
-            ".*Failed to insert into table 'enum_table': "
             "Could not convert string 'd' to UINT8"
         ),
     ):

--- a/tests/test_duckdb/test_relation.py
+++ b/tests/test_duckdb/test_relation.py
@@ -384,7 +384,7 @@ def test_relation_case_method():
         }
     )
 
-    correct_df = df.with_column(
+    correct_df = df.with_columns(
         pl.Series([10, 20, 10, 0, None], dtype=pl.Int32).alias("max_weight")
     )
     correct_mapped_actions = db.to_relation(correct_df)

--- a/tests/test_duckdb/test_relation.py
+++ b/tests/test_duckdb/test_relation.py
@@ -655,7 +655,7 @@ def test_with_missing_nullable_enum_columns():
         table="enum_table"
     )
     table_relation = db.table("enum_table")
-    assert table_relation.types["enum_column"].startswith("enum__")
+    assert(str(table_relation.types["enum_column"]).startswith("enum__"))
 
     # We generate another dynamic relation where we expect the correct enum type
     null_relation = (
@@ -696,7 +696,7 @@ def test_with_missing_nullable_enum_columns_without_table():
         relation.with_missing_nullable_columns()
 
     model_relation = relation.set_model(EnumModel).with_missing_nullable_columns()
-    assert model_relation.types["enum_column_1"].startswith("enum__")
+    assert str(model_relation.types["enum_column_1"]).startswith("enum__")
     assert (
         model_relation.types["enum_column_2"] == model_relation.types["enum_column_1"]
     )
@@ -728,7 +728,7 @@ def test_with_missing_defualtable_enum_columns():
         relation.with_missing_defaultable_columns()
 
     model_relation = relation.set_model(EnumModel).with_missing_defaultable_columns()
-    assert model_relation.types["enum_column"].startswith("enum__")
+    assert str(model_relation.types["enum_column"]).startswith("enum__")
 
 
 def test_relation_insert_into():

--- a/tests/test_dummy_data.py
+++ b/tests/test_dummy_data.py
@@ -111,7 +111,7 @@ def test_enum_field_example_values():
         none_default_optional_enum_field: Optional[Literal["a", "b", "c"]] = None
 
     # Workaround for pola-rs/polars#4253
-    example_df = DefaultEnumModel.examples({"row_number": [1]}).with_column(
+    example_df = DefaultEnumModel.examples({"row_number": [1]}).with_columns(
         pl.col("none_default_optional_enum_field").cast(pl.Categorical)
     )
 

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -82,7 +82,7 @@ def test_preservation_of_model():
 
     # First many eagerly executed method calls
     assert (
-        df_with_model.with_column(pl.lit(1).alias("a"))
+        df_with_model.with_columns(pl.lit(1).alias("a"))
         .filter(pl.lit(1) == 1)
         .select(pl.col("a"))
         .model

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -382,7 +382,7 @@ def test_validation_of_bounds_checks():
     )
 
     valid = [42.5, 42.4, 42.5, 42.6, 42.6, 19.5, 3.1415, "value X", "ab", "ab"]
-    valid_df = pl.DataFrame(data=[valid], columns=BoundModel.columns)
+    valid_df = pl.DataFrame(data=[valid], schema=BoundModel.columns)
     BoundModel.validate(valid_df)
 
     invalid = [42.6, 42.5, 42.4, 42.5, 43.1, 19.75, 3.2, "value x", "a", "abc"]
@@ -392,7 +392,7 @@ def test_validation_of_bounds_checks():
             + invalid[column_index : column_index + 1]
             + valid[column_index + 1 :]
         )
-        invalid_df = pl.DataFrame(data=[data], columns=BoundModel.columns)
+        invalid_df = pl.DataFrame(data=[data], schema=BoundModel.columns)
         with pytest.raises(ValidationError) as e_info:
             BoundModel.validate(invalid_df)
         errors = e_info.value.errors()
@@ -432,7 +432,7 @@ def test_validation_of_dtype_specifiers():
         pl.Series([2]).cast(pl.UInt64),
         pl.Series([2]).cast(pl.UInt8),
     ]
-    valid_df = pl.DataFrame(data=valid, columns=DTypeModel.columns)
+    valid_df = pl.DataFrame(data=valid, schema=DTypeModel.columns)
     DTypeModel.validate(valid_df)
 
     invalid = [
@@ -453,7 +453,7 @@ def test_validation_of_dtype_specifiers():
             + invalid[column_index : column_index + 1]
             + valid[column_index + 1 :]
         )
-        invalid_df = pl.DataFrame(data=data, columns=DTypeModel.columns)
+        invalid_df = pl.DataFrame(data=data, schema=DTypeModel.columns)
         with pytest.raises(ValidationError) as e_info:
             DTypeModel.validate(invalid_df)
         errors = e_info.value.errors()

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -187,7 +187,7 @@ def test_validate_dtype_checks():
 
         with pytest.raises(ValidationError) as e_info:
             validate(
-                dataframe=valid_df.with_column(pl.lit(1, dtype=dtype).alias(column)),
+                dataframe=valid_df.with_columns(pl.lit(1, dtype=dtype).alias(column)),
                 schema=CompleteModel,
             )
 
@@ -226,7 +226,7 @@ def test_validate_dtype_checks():
 
     pytest.importorskip("pandas")
     validate(
-        dataframe=valid_df.with_column(pl.col("date_column").cast(str)).to_pandas(),
+        dataframe=valid_df.with_columns(pl.col("date_column").cast(str)).to_pandas(),
         schema=PandasCompatibleModel,
     )
 
@@ -257,9 +257,9 @@ def test_datetime_validation():
     needs to check the "format" property on the field schema.
     """
 
-    string_df = pl.DataFrame().with_column(pl.lit("string", dtype=pl.Utf8).alias("c"))
-    date_df = pl.DataFrame().with_column(pl.lit(date.today(), dtype=pl.Date).alias("c"))
-    datetime_df = pl.DataFrame().with_column(
+    string_df = pl.DataFrame().with_columns(pl.lit("string", dtype=pl.Utf8).alias("c"))
+    date_df = pl.DataFrame().with_columns(pl.lit(date.today(), dtype=pl.Date).alias("c"))
+    datetime_df = pl.DataFrame().with_columns(
         pl.lit(datetime.now(), dtype=pl.Datetime).alias("c")
     )
 
@@ -595,4 +595,4 @@ def test_validation_of_list_dtypes():
     ]:
         # print(old, new)
         with pytest.raises(ValidationError):
-            ListModel.validate(valid_df.with_column(pl.col(old).alias(new)))
+            ListModel.validate(valid_df.with_columns(pl.col(old).alias(new)))


### PR DESCRIPTION
Hi @JakobGM, @johanbog and I have updated patito to support the latest polars and duckdb versions.
If you can prioritize taking a look, then I would appreciate it.

I have *not* updated the poetry lockfile, as I had some trouble using poetry.